### PR TITLE
Fix packer template RegExp

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,7 @@ export default {
       lintsOnChange: false,
       lint: (activeEditor) => {
         // bail out if this is not a packer template
-        if (!(/"builders": \[/.exec(activeEditor.getText())))
+        if (!(/"builders"\s*:\s*\[/.exec(activeEditor.getText())))
           return [];
 
         // establish const vars


### PR DESCRIPTION
Linter not triggered on my packer file, because I use this pattern: "value" : "key" 
With this fix, the linter will be triggered on -> "builders" + zero or multi whitespace + ":" + zero or multi whitespace + "["